### PR TITLE
Se corrige versión mínima del paquete de idioma.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "metapackage",
   "require": {
     "php": "~7.2.0|~7.3.0|~7.4.0",
-    "mugar/language_es-ar": "~0.3",
+    "mugar/language_es-ar": "~0.1",
     "mugar/module-argentina-regions": "~2.0"
   },
   "license": [


### PR DESCRIPTION
Hice un cambio posterior al ordenar el paquete de idioma y quedó mal la restricción de versiones.

